### PR TITLE
Add empty line support

### DIFF
--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -45,11 +45,11 @@ impl Filelist {
 }
 
 /// Parses a filelist file.
-/// 
-/// Environment variables represented with paranthesis or 
+///
+/// Environment variables represented with paranthesis or
 /// curly braces (i.e. `$()` or `${}`) will be automatically
 /// substituted.
-/// 
+///
 /// # Arguments
 ///
 /// * `path` - The path to the filelist
@@ -84,6 +84,7 @@ pub fn parse_file(path: impl AsRef<Path>) -> Result<Filelist, Box<dyn Error>> {
             }
             LineType::Comment => filelist.comments_present = true,
             LineType::Unknown => filelist.unknowns_present = true,
+            LineType::Empty => (),
             LineType::Filelist(path) => {
                 filelist.extend(parse_file(path)?);
             }

--- a/src/line_parser.rs
+++ b/src/line_parser.rs
@@ -8,6 +8,7 @@ pub enum LineType<'a> {
     Filelist(&'a str),
     Comment,
     Unknown,
+    Empty,
 }
 
 pub fn parse_line(line: &str) -> LineType {
@@ -37,6 +38,8 @@ pub fn parse_line(line: &str) -> LineType {
         LineType::Comment
     } else if line.starts_with('-') || line.starts_with('+') {
         LineType::Unknown
+    } else if line.is_empty() {
+        LineType::Empty
     } else {
         // Mark everything else as a File
         LineType::File(line)
@@ -107,6 +110,16 @@ mod test {
     fn parse_line_unknown_plus() {
         let line = "+funcmd";
         assert_eq!(parse_line(line), LineType::Unknown);
+    }
+
+    #[test]
+    fn parse_line_empty() {
+        let line = "";
+        assert_eq!(parse_line(line), LineType::Empty);
+        let line = " ";
+        assert_eq!(parse_line(line), LineType::Empty);
+        let line = "\t";
+        assert_eq!(parse_line(line), LineType::Empty);
     }
 
     #[test]


### PR DESCRIPTION
Currently empty line is parsed as `Filelist("")`.
This PR fixes it.

https://github.com/dalance/svlint/issues/15