### PR TITLE
Substitute bare environment variables without braces or parentheses.

### DIFF
--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -97,6 +97,7 @@ pub fn parse_file(path: impl AsRef<Path>) -> Result<Filelist, Box<dyn Error>> {
 fn replace_env_vars(line: &str) -> String {
     let re_env_brace = Regex::new(r"\$\{(?P<env>[^}]+)\}").unwrap();
     let re_env_paren = Regex::new(r"\$\((?P<env>[^)]+)\)").unwrap();
+    let re_env_bare = Regex::new(r"\$(?P<env>[a-zA-Z_][a-zA-Z0-9_]*)").unwrap();
 
     let mut expanded_line = String::from(line);
     for caps in re_env_brace.captures_iter(&line) {
@@ -109,6 +110,12 @@ fn replace_env_vars(line: &str) -> String {
         let env = &caps["env"];
         if let Ok(env_var) = std::env::var(env) {
             expanded_line = expanded_line.replace(&format!("$({})", env), &env_var);
+        }
+    }
+    for caps in re_env_bare.captures_iter(&line) {
+        let env = &caps["env"];
+        if let Ok(env_var) = std::env::var(env) {
+            expanded_line = expanded_line.replace(&format!("${}", env), &env_var);
         }
     }
     expanded_line

--- a/testcase/files.f
+++ b/testcase/files.f
@@ -6,5 +6,6 @@ testcase/file3.sv
 +define+a=b+c=d+e=f
 +define+$(VAR1)=var1
 +define+${VAR2}=var2
++define+$VAR3=var3
 +define+RTL
 -f testcase/files2.f

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,6 +10,7 @@ fn simple_test() {
     defines.insert("c".to_string(), Some("d".to_string()));
     defines.insert("ENV_VAR1".to_string(), Some("var1".to_string()));
     defines.insert("ENV_VAR2".to_string(), Some("var2".to_string()));
+    defines.insert("ENV_VAR3".to_string(), Some("var3".to_string()));
     defines.insert("RTL".to_string(), None);
 
     let filelist_exp = verilog_filelist_parser::Filelist {
@@ -28,6 +29,7 @@ fn simple_test() {
     // Add env vars
     std::env::set_var("VAR1", "ENV_VAR1");
     std::env::set_var("VAR2", "ENV_VAR2");
+    std::env::set_var("VAR3", "ENV_VAR3");
 
     let filelist = verilog_filelist_parser::parse_file("testcase/files.f").expect("Error parsing");
     assert_eq!(filelist_exp, filelist);


### PR DESCRIPTION
Address the same issue as <https://github.com/dalance/svlint/issues/134> - lots of existing filelists without brackets or parentheses.

Regex is based on:
- <https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names>
- <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_235>

@jacklee023 Does this address your issue? svlint would need to update the dependency on this library before the change is usable.

@Raamakrishnan If you merge this, would you also make a release for svlint and other downstream packages.